### PR TITLE
Admin Board - Tabs implementation (admin-home, bookings list table, meals management, global settings) 

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,7 +1,7 @@
 // Entry point for the build script in your package.json
-import "@hotwired/turbo-rails"
-import "./controllers"
-import { initFlatpickr } from "./plugins/flatpickr";
-window.addEventListener("turbo:load", function(){
-initFlatpickr();
+import '@hotwired/turbo-rails';
+import './controllers';
+import { initFlatpickr } from './plugins/flatpickr';
+window.addEventListener('turbo:load', function () {
+  initFlatpickr();
 });

--- a/app/javascript/controllers/admin_controller.js
+++ b/app/javascript/controllers/admin_controller.js
@@ -6,9 +6,63 @@ export default class extends Controller {
   connect() {}
 
   tabs(event) {
-    event.currentTarget.innerHTML = `<a href="" class="inline-flex p-4 text-blue-600 border-b-2 border-blue-600 rounded-t-lg active dark:text-blue-500 dark:border-blue-500 group" aria-current="page">
-        <svg aria-hidden="true" class="w-5 h-5 mr-2 text-blue-600 dark:text-blue-500" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M5 3a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 00-2-2H5zM5 11a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2v-2a2 2 0 00-2-2H5zM11 5a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V5zM11 13a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"></path></svg>${event.currentTarget.innerText}
-      </a>`;
-    // const currentTab = event.currentTarget.id;
+    event.preventDefault();
+    const activeLinkClasses = [
+      'inline-flex',
+      'p-4',
+      'text-blue-600',
+      'border-b-2',
+      'border-blue-600',
+      'rounded-t-lg',
+      'active',
+      'dark:text-blue-500',
+      'dark:border-blue-500',
+      'group',
+    ];
+    const inactiveLinkClasses = [
+      'inline-flex',
+      'p-4',
+      'border-b-2',
+      'border-transparent',
+      'rounded-t-lg',
+      'hover:text-gray-600',
+      'hover:border-gray-300',
+      'dark:hover:text-gray-300',
+      'group',
+    ];
+    const activeSvgClasses = ['text-blue-600', 'dark:text-blue-500'];
+    const inactiveSvgClasses = [
+      'text-gray-400',
+      'group-hover:text-gray-500',
+      'dark:text-gray-500',
+      'dark:group-hover:text-gray-300',
+    ];
+
+    this.tabTargets.forEach((tab) => {
+      tab.querySelector('a').classList.remove(...activeLinkClasses);
+      tab.querySelector('a').classList.add(...inactiveLinkClasses);
+      tab.querySelector('svg').classList.remove(...activeSvgClasses);
+      tab.querySelector('svg').classList.add(...inactiveSvgClasses);
+    });
+
+    event.currentTarget
+      .querySelector('a')
+      .classList.remove(...inactiveLinkClasses);
+    event.currentTarget.querySelector('a').classList.add(...activeLinkClasses);
+    event.currentTarget
+      .querySelector('svg')
+      .classList.remove(...inactiveSvgClasses);
+    event.currentTarget.querySelector('svg').classList.add(...activeSvgClasses);
+
+    this.tabTargets.forEach((tab) => {
+      document
+        .querySelector(`#active-${tab.id}`)
+        .classList.replace('block', 'hidden');
+    });
+
+    const currentTab = event.currentTarget.id;
+    document
+      .querySelector(`#active-${currentTab}`)
+      .classList.replace('hidden', 'block');
   }
 }

--- a/app/javascript/controllers/admin_controller.js
+++ b/app/javascript/controllers/admin_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from '@hotwired/stimulus';
+
+// Connects to data-controller="admin"
+export default class extends Controller {
+  static targets = ['tab'];
+  connect() {}
+
+  tabs(event) {
+    event.currentTarget.innerHTML = `<a href="" class="inline-flex p-4 text-blue-600 border-b-2 border-blue-600 rounded-t-lg active dark:text-blue-500 dark:border-blue-500 group" aria-current="page">
+        <svg aria-hidden="true" class="w-5 h-5 mr-2 text-blue-600 dark:text-blue-500" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M5 3a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 00-2-2H5zM5 11a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2v-2a2 2 0 00-2-2H5zM11 5a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V5zM11 13a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"></path></svg>${event.currentTarget.innerText}
+      </a>`;
+    // const currentTab = event.currentTarget.id;
+  }
+}

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,7 @@
-import { Controller } from "@hotwired/stimulus"
+import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
   connect() {
-    this.element.textContent = "Hello World!"
+    this.element.textContent = 'Hello World!';
   }
 }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,5 +4,8 @@
 
 import { application } from "./application"
 
+import AdminController from "./admin_controller"
+application.register("admin", AdminController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)

--- a/app/views/pages/admin.html.erb
+++ b/app/views/pages/admin.html.erb
@@ -9,13 +9,13 @@
   <div class="border-b border-gray-200 dark:border-gray-700">
       <ul class="flex flex-wrap -mb-px text-sm font-medium text-center text-gray-500 dark:text-gray-400">
           <li data-action="click->admin#tabs" id="home-tab" class="mr-2" data-admin-target="tab">
-              <a href="" class="inline-flex p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300 group">
-                  <svg aria-hidden="true" class="w-5 h-5 mr-2 text-gray-400 group-hover:text-gray-500 dark:text-gray-500 dark:group-hover:text-gray-300" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-6-3a2 2 0 11-4 0 2 2 0 014 0zm-2 4a5 5 0 00-4.546 2.916A5.986 5.986 0 0010 16a5.986 5.986 0 004.546-2.084A5 5 0 0010 11z" clip-rule="evenodd"></path></svg>Accueil
+              <a href="" class="inline-flex p-4 text-blue-600 border-b-2 border-blue-600 rounded-t-lg active dark:text-blue-500 dark:border-blue-500 group">
+                  <svg aria-hidden="true" class="w-5 h-5 mr-2 text-blue-600 dark:text-blue-500" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-6-3a2 2 0 11-4 0 2 2 0 014 0zm-2 4a5 5 0 00-4.546 2.916A5.986 5.986 0 0010 16a5.986 5.986 0 004.546-2.084A5 5 0 0010 11z" clip-rule="evenodd"></path></svg>Accueil
               </a>
           </li>
           <li data-action="click->admin#tabs" id="bookings-tab" class="mr-2" data-admin-target="tab">
-              <a href="" class="inline-flex p-4 text-blue-600 border-b-2 border-blue-600 rounded-t-lg active dark:text-blue-500 dark:border-blue-500 group" aria-current="page">
-                  <svg aria-hidden="true" class="w-5 h-5 mr-2 text-blue-600 dark:text-blue-500" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M5 3a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 00-2-2H5zM5 11a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2v-2a2 2 0 00-2-2H5zM11 5a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V5zM11 13a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"></path></svg>Réservations
+              <a href="" class="inline-flex p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300 group">
+                  <svg aria-hidden="true" class="w-5 h-5 mr-2 text-gray-400 group-hover:text-gray-500 dark:text-gray-500 dark:group-hover:text-gray-300" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M5 3a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 00-2-2H5zM5 11a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2v-2a2 2 0 00-2-2H5zM11 5a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V5zM11 13a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"></path></svg>Réservations
               </a>
           </li>
           <li data-action="click->admin#tabs" id="meals-tab" class="mr-2" data-admin-target="tab">
@@ -28,22 +28,22 @@
                   <svg aria-hidden="true" class="w-5 h-5 mr-2 text-gray-400 group-hover:text-gray-500 dark:text-gray-500 dark:group-hover:text-gray-300" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"></path><path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"></path></svg>Paramètres
               </a>
           </li>
-          <li data-action="click->admin#tabs" id="disabled-tab" >
-              <a class="inline-block p-4 text-gray-400 rounded-t-lg cursor-not-allowed dark:text-gray-500">Disabled</a>
-          </li>
+          <%# <li id="disabled-tab" >
+              <a class="inline-block p-4 text-gray-400 rounded-t-lg cursor-not-allowed dark:text-gray-500">Disabled (for test only)</a>
+          </li> %>
       </ul>
   </div>
 
   <%# ACCUEIL %>
-  <div id="admin-home" class="block">CONTENT HOME</div>
+  <div id="active-home-tab" class="block">CONTENT HOME</div>
 
   <%# BOOKING LIST %>
-  <div id="admin-bookings" class="hidden"><%= render "shared/bookings-table", bookings: @bookings %></div>
+  <div id="active-bookings-tab" class="hidden"><%= render "shared/bookings-table", bookings: @bookings %></div>
 
   <%# MENUS %>
-  <div id="admin-meals" class="hidden">CONTENT MEALS</div>
+  <div id="active-meals-tab" class="hidden">CONTENT MEALS</div>
 
   <%# SETTINGS %>
-  <div id="settings" class="hidden">SETTINGS</div>
+  <div id="active-settings-tab" class="hidden">SETTINGS</div>
 
 </div>

--- a/app/views/pages/admin.html.erb
+++ b/app/views/pages/admin.html.erb
@@ -1,10 +1,49 @@
-<div class="px-32 py-64"> <%# Padding to adjust later %>
+<div class="px-32 py-64" data-controller="admin"> <%# Padding to adjust later %>
 
   <div class="flex flex-row items-center justify-between pb-16">
     <h2 class="text-lg font-medium text-pink-pastel">Liste des réservations en cours</h2>
     <%= link_to "Déconnexion", destroy_user_session_path, class: "rounded-md bg-pink-pastel px-8 py-2.5 text-base font-medium text-white shadow", data: {turbo_method: :delete} %>
   </div>
 
-  <%= render "shared/bookings-table", bookings: @bookings %>
+  <%# ADMIN TABS %>
+  <div class="border-b border-gray-200 dark:border-gray-700">
+      <ul class="flex flex-wrap -mb-px text-sm font-medium text-center text-gray-500 dark:text-gray-400">
+          <li data-action="click->admin#tabs" id="home-tab" class="mr-2" data-admin-target="tab">
+              <a href="" class="inline-flex p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300 group">
+                  <svg aria-hidden="true" class="w-5 h-5 mr-2 text-gray-400 group-hover:text-gray-500 dark:text-gray-500 dark:group-hover:text-gray-300" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-6-3a2 2 0 11-4 0 2 2 0 014 0zm-2 4a5 5 0 00-4.546 2.916A5.986 5.986 0 0010 16a5.986 5.986 0 004.546-2.084A5 5 0 0010 11z" clip-rule="evenodd"></path></svg>Accueil
+              </a>
+          </li>
+          <li data-action="click->admin#tabs" id="bookings-tab" class="mr-2" data-admin-target="tab">
+              <a href="" class="inline-flex p-4 text-blue-600 border-b-2 border-blue-600 rounded-t-lg active dark:text-blue-500 dark:border-blue-500 group" aria-current="page">
+                  <svg aria-hidden="true" class="w-5 h-5 mr-2 text-blue-600 dark:text-blue-500" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M5 3a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 00-2-2H5zM5 11a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2v-2a2 2 0 00-2-2H5zM11 5a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V5zM11 13a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"></path></svg>Réservations
+              </a>
+          </li>
+          <li data-action="click->admin#tabs" id="meals-tab" class="mr-2" data-admin-target="tab">
+              <a href="" class="inline-flex p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300 group">
+                  <svg aria-hidden="true" class="w-5 h-5 mr-2 text-gray-400 group-hover:text-gray-500 dark:text-gray-500 dark:group-hover:text-gray-300" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M5 4a1 1 0 00-2 0v7.268a2 2 0 000 3.464V16a1 1 0 102 0v-1.268a2 2 0 000-3.464V4zM11 4a1 1 0 10-2 0v1.268a2 2 0 000 3.464V16a1 1 0 102 0V8.732a2 2 0 000-3.464V4zM16 3a1 1 0 011 1v7.268a2 2 0 010 3.464V16a1 1 0 11-2 0v-1.268a2 2 0 010-3.464V4a1 1 0 011-1z"></path></svg>Menus
+              </a>
+          </li>
+          <li data-action="click->admin#tabs" id="settings-tab" class="mr-2" data-admin-target="tab">
+              <a href="" class="inline-flex p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300 group">
+                  <svg aria-hidden="true" class="w-5 h-5 mr-2 text-gray-400 group-hover:text-gray-500 dark:text-gray-500 dark:group-hover:text-gray-300" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"></path><path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"></path></svg>Paramètres
+              </a>
+          </li>
+          <li data-action="click->admin#tabs" id="disabled-tab" >
+              <a class="inline-block p-4 text-gray-400 rounded-t-lg cursor-not-allowed dark:text-gray-500">Disabled</a>
+          </li>
+      </ul>
+  </div>
+
+  <%# ACCUEIL %>
+  <div id="admin-home" class="block">CONTENT HOME</div>
+
+  <%# BOOKING LIST %>
+  <div id="admin-bookings" class="hidden"><%= render "shared/bookings-table", bookings: @bookings %></div>
+
+  <%# MENUS %>
+  <div id="admin-meals" class="hidden">CONTENT MEALS</div>
+
+  <%# SETTINGS %>
+  <div id="settings" class="hidden">SETTINGS</div>
 
 </div>

--- a/app/views/shared/_bookings-table.html.erb
+++ b/app/views/shared/_bookings-table.html.erb
@@ -1,4 +1,4 @@
-<table class="text-sm table-auto">
+<table id="booking-list" class="text-sm table-auto">
     <thead>
       <tr>
         <% ['', 'Nom', 'Prénom', 'Email', 'Téléphone', 'Date', 'Heure', 'Couverts', 'Message', 'Statut', 'Actions'].each do |head| %>


### PR DESCRIPTION
## Admin Board - Adding navigation tabs through different panels

- Home tab : to be set up with current capacity, new bookings, day-to-day widgets
- Bookings tab : the table (already set up, more coming + filtering) listing all the current bookings made by clients
- Meals tab : to be set up with meals and menu management (encapsulation of MealsController methods?)
- Settings tab : to be set up with all admin settings and options (capacity, closing days, etc.)

## Code & Tech

In order to comply with TailwindCSS classes and avoid creating any conflict, these tabs were built using StimulusJS.
An admin_controller was created in app > javascript > controllers. It has - at the moment - one main function named 'tab', taking the current event has a parameter, and toggling all `<a>` and `<svg>` classes inside the tab targets (the `<li>` encapsulating tabs in the tab bar). This function also sets the current content `<div>` to display to the admin, depending on which tab has been selected.

If you need to bring new things to this **admin_controller**, please run `bundle install && yarn install` in shell to make sure StimulusJS is set up locally.
